### PR TITLE
Feat/calendar events: 캘린더 버그 수정, 스타일 수정

### DIFF
--- a/src/app/artist/[id]/schedule/page.tsx
+++ b/src/app/artist/[id]/schedule/page.tsx
@@ -3,7 +3,6 @@ import { getDaysInMonth, getMonth, getYear } from 'date-fns';
 import ScheduleList from '@/components/calendar/ScheduleList';
 import getInitialSchedules from '@/queries/getInitialSchedules';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
-import { createClient } from '@/utils/supabase/server';
 
 export default async function page({ params }: { params: { id: string } }) {
   const id = params.id;
@@ -22,19 +21,11 @@ export default async function page({ params }: { params: { id: string } }) {
     queryFn: () => getInitialSchedules(artistId, startDate, endDate),
   });
 
-  // TODO: 유나님이 zustand에 session 정보 통합해주시면 그 데이터로 변경
-  const client = createClient();
-  const { data: sessionData, error } = await client.auth.getSession();
-
-  if (error) throw new Error(error.message);
-  console.log('userId: ', sessionData.session?.user.id);
-  const userId = sessionData.session?.user.id;
-
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <div className='flex justify-center items-start gap-10 w-full mt-14'>
         <div className='border p-5 w-[900px]'>
-          <h3>{artistId}</h3>
+          <h3 className='font-bold'>{artistId} 스케줄</h3>
           <Calendar
             artistId={artistId}
             userId={userId}

--- a/src/app/artist/[id]/schedule/page.tsx
+++ b/src/app/artist/[id]/schedule/page.tsx
@@ -36,13 +36,11 @@ export default async function page({ params }: { params: { id: string } }) {
         <div className='border p-5 w-[900px]'>
           <h3>{artistId}</h3>
           <Calendar
-            initialDate={today}
             artistId={artistId}
             userId={userId}
           />
         </div>
         <ScheduleList
-          initialDate={today}
           artistId={artistId}
           userId={userId}
         />

--- a/src/app/artist/[id]/schedule/page.tsx
+++ b/src/app/artist/[id]/schedule/page.tsx
@@ -26,15 +26,9 @@ export default async function page({ params }: { params: { id: string } }) {
       <div className='flex justify-center items-start gap-10 w-full mt-14'>
         <div className='border p-5 w-[900px]'>
           <h3 className='font-bold'>{artistId} 스케줄</h3>
-          <Calendar
-            artistId={artistId}
-            userId={userId}
-          />
+          <Calendar artistId={artistId} />
         </div>
-        <ScheduleList
-          artistId={artistId}
-          userId={userId}
-        />
+        <ScheduleList artistId={artistId} />
       </div>
     </HydrationBoundary>
   );

--- a/src/components/calendar/AddScheduleButton.tsx
+++ b/src/components/calendar/AddScheduleButton.tsx
@@ -78,6 +78,8 @@ export default function AddScheduleButton({ artistId }: { artistId: string }) {
       {
         onSuccess: () => {
           reset();
+          setValue('date', new Date());
+          setDate(new Date());
           setOpen(false);
         },
       },
@@ -86,6 +88,8 @@ export default function AddScheduleButton({ artistId }: { artistId: string }) {
 
   const handleDialogClose = () => {
     reset();
+    setValue('date', new Date());
+    setDate(new Date());
     setOpen(!open);
   };
 

--- a/src/components/calendar/AddScheduleButton.tsx
+++ b/src/components/calendar/AddScheduleButton.tsx
@@ -20,11 +20,13 @@ import { Plus } from 'lucide-react';
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useAuthStore } from '@/lib/stores/useAuthStore';
 
-// TODO: zustand userId 세팅 머지 후 artistId만 받아오기
-export default function AddScheduleButton({ artistId, userId }: { artistId: string; userId: string | undefined }) {
+export default function AddScheduleButton({ artistId }: { artistId: string }) {
   const [date, setDate] = useState<Date | undefined>(new Date());
   const [open, setOpen] = useState(false);
+
+  const { user } = useAuthStore((state) => state);
 
   const scheduleSchema = z.object({
     title: z.string().min(1, { message: '스케줄 이름을 입력해주세요.' }),
@@ -58,7 +60,7 @@ export default function AddScheduleButton({ artistId, userId }: { artistId: stri
 
   const { mutate: mutateSchedule } = useMutateSchedule();
   const onSubmit = (data: ScheduleFormValues) => {
-    if (!userId) {
+    if (!user) {
       // TODO: shadcn confirm dialog로 변경 -> 로그인 페이지로 이동?
       alert('잘못된 유저정보입니다. 다시 로그인해주세요.');
       return;
@@ -71,7 +73,7 @@ export default function AddScheduleButton({ artistId, userId }: { artistId: stri
         date: format(data.date, 'yyyy-MM-dd'),
         content: data.content || null,
         description: data.description,
-        user_id: userId,
+        user_id: user.id,
       },
       {
         onSuccess: () => {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -5,7 +5,7 @@ import { useFetchSchedules } from '@/queries/fetchSchedules';
 import useScheduleStore from '@/lib/stores/useScheduleStore';
 import { cn } from '@/lib/utils';
 import { getFirstDayOfMonth, isSameDay } from '@/utils/calendar/calendarUtils';
-import AddScheduleButton from '@/components/calendar/AddScheduleButton';
+import ScheduleAddButton from '@/components/calendar/ScheduleAddButton';
 import CalendarControllBotton from '@/components/calendar/CalendarControllBotton';
 
 const DAYS: string[] = ['일', '월', '화', '수', '목', '금', '토'];
@@ -35,7 +35,7 @@ export default function Calendar({ artistId }: { artistId: string }) {
           </h2>
           <CalendarControllBotton mode='next' />
         </div>
-        <AddScheduleButton artistId={artistId} />
+        <ScheduleAddButton artistId={artistId} />
       </div>
       <div className='grid grid-cols-7 w-full text-center'>
         {DAYS.map((day, index) => {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { CalendarInitDataType } from '@/lib/type/scheduleTypes';
 import { getDaysInMonth } from 'date-fns';
 import { useFetchSchedules } from '@/queries/fetchSchedules';
 import useScheduleStore from '@/lib/stores/useScheduleStore';

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -85,7 +85,7 @@ export default function Calendar({ initialDate, artistId, userId }: TempClanedar
                       return (
                         <div
                           key={schedule.id}
-                          className='bg-svt-rosequartz/50 rounded font-bold p-2 text-gray-700 leading-[12px] text-[12px]'
+                          className='bg-svt-rosequartz/50 rounded font-bold py-[5px] px-3 text-gray-700 leading-[12px] text-[12px]'
                         >
                           {schedule.title}
                         </div>

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -11,12 +11,7 @@ import CalendarControllBotton from '@/components/calendar/CalendarControllBotton
 
 const DAYS: string[] = ['일', '월', '화', '수', '목', '금', '토'];
 
-// TODO: zustand에 userId 세팅 후에는 CalendarInitDataType으로만 prop type 지정
-type TempClanedarInitType = CalendarInitDataType & {
-  userId: string | undefined;
-};
-
-export default function Calendar({ artistId, userId }: TempClanedarInitType) {
+export default function Calendar({ artistId }: { artistId: string }) {
   const { calendarDate, selectedDate, selectDate } = useScheduleStore((state) => state);
   const daysInMonth = getDaysInMonth(calendarDate);
   const firstDay = getFirstDayOfMonth(calendarDate);
@@ -41,10 +36,7 @@ export default function Calendar({ artistId, userId }: TempClanedarInitType) {
           </h2>
           <CalendarControllBotton mode='next' />
         </div>
-        <AddScheduleButton
-          artistId={artistId}
-          userId={userId}
-        />
+        <AddScheduleButton artistId={artistId} />
       </div>
       <div className='grid grid-cols-7 w-full text-center'>
         {DAYS.map((day, index) => {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -2,7 +2,6 @@
 
 import { CalendarInitDataType } from '@/lib/type/scheduleTypes';
 import { getDaysInMonth } from 'date-fns';
-import { useState } from 'react';
 import { useFetchSchedules } from '@/queries/fetchSchedules';
 import useScheduleStore from '@/lib/stores/useScheduleStore';
 import { cn } from '@/lib/utils';
@@ -17,13 +16,12 @@ type TempClanedarInitType = CalendarInitDataType & {
   userId: string | undefined;
 };
 
-export default function Calendar({ initialDate, artistId, userId }: TempClanedarInitType) {
-  const [calendarDate, setCalendarDate] = useState<Date>(initialDate);
+export default function Calendar({ artistId, userId }: TempClanedarInitType) {
+  const { calendarDate, selectedDate, selectDate } = useScheduleStore((state) => state);
   const daysInMonth = getDaysInMonth(calendarDate);
   const firstDay = getFirstDayOfMonth(calendarDate);
 
   const { data: schedules, year, month } = useFetchSchedules(artistId, calendarDate);
-  const { selectedDate, selectDate } = useScheduleStore();
 
   const handleToggleDate = (date: number) => {
     if (selectedDate === date) {
@@ -37,19 +35,11 @@ export default function Calendar({ initialDate, artistId, userId }: TempClanedar
     <div className='flex flex-col justify-center items-center w-full'>
       <div className='grid grid-cols-5 w-full mb-8'>
         <div className='col-start-2 col-end-5 flex gap-3 justify-center items-center'>
-          <CalendarControllBotton
-            mode='previous'
-            calendarDate={calendarDate}
-            setCalendarDate={setCalendarDate}
-          />
+          <CalendarControllBotton mode='previous' />
           <h2 className='text-center'>
             {year} . {month}
           </h2>
-          <CalendarControllBotton
-            mode='next'
-            calendarDate={calendarDate}
-            setCalendarDate={setCalendarDate}
-          />
+          <CalendarControllBotton mode='next' />
         </div>
         <AddScheduleButton
           artistId={artistId}

--- a/src/components/calendar/CalendarControllBotton.tsx
+++ b/src/components/calendar/CalendarControllBotton.tsx
@@ -3,23 +3,25 @@ import { Button } from '@/components/ui/button';
 import { ChevronLeft } from 'lucide-react';
 import { ChevronRight } from 'lucide-react';
 import { add, sub } from 'date-fns';
-import { Dispatch, SetStateAction } from 'react';
+import useScheduleStore from '@/lib/stores/useScheduleStore';
 
 type CalendarControllProps = {
   mode: 'previous' | 'next';
-  calendarDate: Date;
-  setCalendarDate: Dispatch<SetStateAction<Date>>;
 };
 
-export default function CalendarControllBotton({ mode, calendarDate, setCalendarDate }: CalendarControllProps) {
+export default function CalendarControllBotton({ mode }: CalendarControllProps) {
+  const { calendarDate, setCalendarDate, selectDate } = useScheduleStore((state) => state);
+
   const handleControllCalendar = () => {
+    let updatedDate: Date;
     if (mode === 'previous') {
-      const updatedDate = sub(calendarDate, { months: 1 });
-      setCalendarDate(updatedDate);
+      updatedDate = sub(calendarDate, { months: 1 });
     } else {
-      const updatedDate = add(calendarDate, { months: 1 });
-      setCalendarDate(updatedDate);
+      updatedDate = add(calendarDate, { months: 1 });
     }
+
+    setCalendarDate(updatedDate);
+    selectDate(null);
   };
 
   return (

--- a/src/components/calendar/ScheduleAddButton.tsx
+++ b/src/components/calendar/ScheduleAddButton.tsx
@@ -22,6 +22,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuthStore } from '@/lib/stores/useAuthStore';
 import { ko } from 'date-fns/locale';
 import { ScheduleFormValues, scheduleSchema } from '@/utils/zod/scheduleSchema';
+import useRequireSigninDialog from '@/utils/useRequireSigninDialog';
 
 export default function ScheduleAddButton({ artistId }: { artistId: string }) {
   const [date, setDate] = useState<Date | undefined>(new Date());
@@ -45,11 +46,12 @@ export default function ScheduleAddButton({ artistId }: { artistId: string }) {
     },
   });
 
+  const { SignInDialog, showDialog } = useRequireSigninDialog();
+
   const { mutate: mutateSchedule } = useMutateSchedule();
   const onSubmit = (data: ScheduleFormValues) => {
     if (!user) {
-      // TODO: shadcn confirm dialog로 변경 -> 로그인 페이지로 이동?
-      alert('잘못된 유저정보입니다. 다시 로그인해주세요.');
+      showDialog();
       return;
     }
 
@@ -81,100 +83,103 @@ export default function ScheduleAddButton({ artistId }: { artistId: string }) {
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={handleDialogClose}
-    >
-      <div className='flex justify-end mr-5'>
-        <DialogTrigger asChild>
-          <Button
-            className='w-[40px] h-[40px]'
-            variant='default'
-            size='icon'
-          >
-            <Plus strokeWidth='2px' />
-          </Button>
-        </DialogTrigger>
-      </div>
-      <DialogContent>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <DialogHeader>
-            <DialogTitle>스케줄 추가하기</DialogTitle>
-            <DialogDescription>{artistId}의 스케줄을 공유해주세요!</DialogDescription>
-          </DialogHeader>
-          <div className='grid gap-4 py-4'>
-            <div className='grid grid-cols-4 items-center gap-5'>
-              <Label
-                htmlFor='title'
-                className='text-right font-bold text-[16px]'
-              >
-                스케줄 이름 *
-              </Label>
-              <div className='flex flex-col col-span-3'>
-                <Input
-                  id='title'
-                  {...register('title')}
+    <>
+      <SignInDialog />
+      <Dialog
+        open={open}
+        onOpenChange={handleDialogClose}
+      >
+        <div className='flex justify-end mr-5'>
+          <DialogTrigger asChild>
+            <Button
+              className='w-[40px] h-[40px]'
+              variant='default'
+              size='icon'
+            >
+              <Plus strokeWidth='2px' />
+            </Button>
+          </DialogTrigger>
+        </div>
+        <DialogContent>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <DialogHeader>
+              <DialogTitle>스케줄 추가하기</DialogTitle>
+              <DialogDescription>{artistId}의 스케줄을 공유해주세요!</DialogDescription>
+            </DialogHeader>
+            <div className='grid gap-4 py-4'>
+              <div className='grid grid-cols-4 items-center gap-5'>
+                <Label
+                  htmlFor='title'
+                  className='text-right font-bold text-[16px]'
+                >
+                  스케줄 이름 *
+                </Label>
+                <div className='flex flex-col col-span-3'>
+                  <Input
+                    id='title'
+                    {...register('title')}
+                  />
+                  {errors.title && <p className='text-red-500'>{errors.title.message}</p>}
+                </div>
+              </div>
+              <div className='grid grid-cols-4 items-center gap-5'>
+                <Label
+                  htmlFor='date'
+                  className='text-right self-start pt-3 font-bold text-[16px]'
+                >
+                  날짜 *
+                </Label>
+                <Calendar
+                  mode='single'
+                  selected={date}
+                  onSelect={(date) => {
+                    setDate(date);
+                    setValue('date', date as Date);
+                  }}
+                  className='rounded-md'
+                  locale={ko}
                 />
-                {errors.title && <p className='text-red-500'>{errors.title.message}</p>}
+                {errors.date && <p className='text-red-500'>{errors.date.message}</p>}
+              </div>
+              <div className='grid grid-cols-4 items-center gap-5'>
+                <Label
+                  htmlFor='description'
+                  className='text-right font-bold text-[16px]'
+                >
+                  상세 정보 *
+                </Label>
+                <div className='flex flex-col col-span-3'>
+                  <Input
+                    id='description'
+                    placeholder='장소, 시간 등 정보를 입력해주세요'
+                    {...register('description')}
+                  />
+                  {errors.description && <p className='text-red-500'>{errors.description.message}</p>}
+                </div>
+              </div>
+              <div className='grid grid-cols-4 items-center gap-5'>
+                <Label
+                  htmlFor='content'
+                  className='text-right font-bold text-[16px]'
+                >
+                  상세 설명
+                </Label>
+                <div className='flex flex-col col-span-3'>
+                  <Input
+                    id='content'
+                    placeholder='자세한 설명을 입력해주세요'
+                    {...register('content')}
+                  />
+                  {errors.content && <p className='text-red-500'>{errors.content.message}</p>}
+                </div>
               </div>
             </div>
-            <div className='grid grid-cols-4 items-center gap-5'>
-              <Label
-                htmlFor='date'
-                className='text-right self-start pt-3 font-bold text-[16px]'
-              >
-                날짜 *
-              </Label>
-              <Calendar
-                mode='single'
-                selected={date}
-                onSelect={(date) => {
-                  setDate(date);
-                  setValue('date', date as Date);
-                }}
-                className='rounded-md'
-                locale={ko}
-              />
-              {errors.date && <p className='text-red-500'>{errors.date.message}</p>}
-            </div>
-            <div className='grid grid-cols-4 items-center gap-5'>
-              <Label
-                htmlFor='description'
-                className='text-right font-bold text-[16px]'
-              >
-                상세 정보 *
-              </Label>
-              <div className='flex flex-col col-span-3'>
-                <Input
-                  id='description'
-                  placeholder='장소, 시간 등 정보를 입력해주세요'
-                  {...register('description')}
-                />
-                {errors.description && <p className='text-red-500'>{errors.description.message}</p>}
-              </div>
-            </div>
-            <div className='grid grid-cols-4 items-center gap-5'>
-              <Label
-                htmlFor='content'
-                className='text-right font-bold text-[16px]'
-              >
-                상세 설명
-              </Label>
-              <div className='flex flex-col col-span-3'>
-                <Input
-                  id='content'
-                  placeholder='자세한 설명을 입력해주세요'
-                  {...register('content')}
-                />
-                {errors.content && <p className='text-red-500'>{errors.content.message}</p>}
-              </div>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button type='submit'>등록하기</Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+            <DialogFooter>
+              <Button type='submit'>등록하기</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/components/calendar/ScheduleAddButton.tsx
+++ b/src/components/calendar/ScheduleAddButton.tsx
@@ -17,31 +17,17 @@ import { Calendar } from '@/components/ui/calendar';
 import { useMutateSchedule } from '@/queries/fetchSchedules';
 import { format } from 'date-fns';
 import { Plus } from 'lucide-react';
-import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuthStore } from '@/lib/stores/useAuthStore';
 import { ko } from 'date-fns/locale';
+import { ScheduleFormValues, scheduleSchema } from '@/utils/zod/scheduleSchema';
 
 export default function ScheduleAddButton({ artistId }: { artistId: string }) {
   const [date, setDate] = useState<Date | undefined>(new Date());
   const [open, setOpen] = useState(false);
 
   const { user } = useAuthStore((state) => state);
-
-  const scheduleSchema = z.object({
-    title: z.string().min(1, { message: '스케줄 이름을 입력해주세요.' }),
-    description: z.string().min(1, { message: '상세정보를 입력해주세요.' }),
-    date: z
-      .date({ invalid_type_error: '날짜는 Date 객체여야 합니다.' })
-      .nullable()
-      .refine((d) => d !== null, {
-        message: '날짜는 필수 항목입니다.',
-      }),
-    content: z.string().optional(),
-  });
-
-  type ScheduleFormValues = z.infer<typeof scheduleSchema>;
 
   const {
     register,

--- a/src/components/calendar/ScheduleAddButton.tsx
+++ b/src/components/calendar/ScheduleAddButton.tsx
@@ -21,8 +21,9 @@ import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuthStore } from '@/lib/stores/useAuthStore';
+import { ko } from 'date-fns/locale';
 
-export default function AddScheduleButton({ artistId }: { artistId: string }) {
+export default function ScheduleAddButton({ artistId }: { artistId: string }) {
   const [date, setDate] = useState<Date | undefined>(new Date());
   const [open, setOpen] = useState(false);
 
@@ -146,6 +147,7 @@ export default function AddScheduleButton({ artistId }: { artistId: string }) {
                   setValue('date', date as Date);
                 }}
                 className='rounded-md'
+                locale={ko}
               />
               {errors.date && <p className='text-red-500'>{errors.date.message}</p>}
             </div>

--- a/src/components/calendar/ScheduleEditButton.tsx
+++ b/src/components/calendar/ScheduleEditButton.tsx
@@ -2,7 +2,7 @@
 
 import { Pencil } from 'lucide-react';
 import { useUpdateSchedule } from '@/queries/fetchSchedules';
-import { Schedule, ScheduleUpdate } from '@/lib/type/scheduleTypes';
+import { Schedule } from '@/lib/type/scheduleTypes';
 import {
   Dialog,
   DialogContent,

--- a/src/components/calendar/ScheduleEditButton.tsx
+++ b/src/components/calendar/ScheduleEditButton.tsx
@@ -18,6 +18,7 @@ import { Input } from '@/components/ui/input';
 import { Calendar } from '@/components/ui/calendar';
 import { useState } from 'react';
 import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 
 export default function ScheduleEditButton({ schedule }: { schedule: Schedule }) {
   const [open, setOpen] = useState<boolean>(false);
@@ -89,6 +90,7 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
               </Label>
               <Calendar
                 mode='single'
+                locale={ko}
                 selected={date}
                 onSelect={setDate}
                 className='rounded-md'

--- a/src/components/calendar/ScheduleEditButton.tsx
+++ b/src/components/calendar/ScheduleEditButton.tsx
@@ -19,37 +19,66 @@ import { Calendar } from '@/components/ui/calendar';
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ScheduleFormValues, scheduleSchema } from '@/utils/zod/scheduleSchema';
 
 export default function ScheduleEditButton({ schedule }: { schedule: Schedule }) {
+  const [date, setDate] = useState<Date | undefined>(new Date(schedule.date));
   const [open, setOpen] = useState<boolean>(false);
-  const { mutate } = useUpdateSchedule();
-  const [value, setValue] = useState<ScheduleUpdate>({
-    date: schedule.date,
-    content: schedule.content,
-    title: schedule.title,
-    description: schedule.description,
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    setValue,
+  } = useForm<ScheduleFormValues>({
+    resolver: zodResolver(scheduleSchema),
+    defaultValues: {
+      title: schedule.title,
+      description: schedule.description,
+      date: new Date(schedule.date),
+      content: schedule.content,
+    },
   });
 
-  const [date, setDate] = useState<Date | undefined>(new Date(schedule.date));
-
-  const handleEditSchedule = () => {
+  const { mutate } = useUpdateSchedule();
+  const handleEditSchedule = (data: ScheduleFormValues) => {
     if (!date) {
       alert('알맞은 date값이 아닙니다.');
       return;
     }
 
-    const updateData = { scheduleId: schedule.id, ...value, date: format(date, 'yyyy-MM-dd') };
+    const updateData = {
+      scheduleId: schedule.id,
+      title: data.title,
+      date: format(data.date, 'yyyy-MM-dd'),
+      content: data.content,
+      description: data.description,
+    };
+
     mutate(updateData, {
       onSuccess: () => {
+        reset();
+        setValue('date', new Date(schedule.date));
+        setDate(new Date(schedule.date));
         setOpen(false);
       },
     });
   };
 
+  const handleDialogClose = () => {
+    reset();
+    setValue('date', new Date(schedule.date));
+    setDate(new Date(schedule.date));
+    setOpen(!open);
+  };
+
   return (
     <Dialog
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleDialogClose}
     >
       <div className='flex justify-end mr-5'>
         <DialogTrigger asChild>
@@ -61,7 +90,7 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
         </DialogTrigger>
       </div>
       <DialogContent>
-        <form onSubmit={handleEditSchedule}>
+        <form onSubmit={handleSubmit(handleEditSchedule)}>
           <DialogHeader>
             <DialogTitle>스케줄 추가하기</DialogTitle>
             <DialogDescription>{schedule.artist_id}의 스케줄을 공유해주세요!</DialogDescription>
@@ -74,12 +103,13 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
               >
                 스케줄 이름 *
               </Label>
-              <Input
-                id='title'
-                className='col-span-3'
-                value={value.title}
-                onChange={(e) => setValue({ ...value, title: e.target.value })}
-              />
+              <div className='flex flex-col col-span-3'>
+                <Input
+                  id='title'
+                  {...register('title')}
+                />
+                {errors.title && <p className='text-red-500'>{errors.title.message}</p>}
+              </div>
             </div>
             <div className='grid grid-cols-4 items-center gap-5'>
               <Label
@@ -92,7 +122,10 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
                 mode='single'
                 locale={ko}
                 selected={date}
-                onSelect={setDate}
+                onSelect={(date) => {
+                  setDate(date);
+                  setValue('date', date as Date);
+                }}
                 className='rounded-md'
               />
             </div>
@@ -103,13 +136,14 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
               >
                 상세 정보 *
               </Label>
-              <Input
-                id='description'
-                placeholder='장소, 시간 등 정보를 입력해주세요'
-                className='col-span-3'
-                value={value.description}
-                onChange={(e) => setValue({ ...value, description: e.target.value })}
-              />
+              <div className='flex flex-col col-span-3'>
+                <Input
+                  id='description'
+                  placeholder='장소, 시간 등 정보를 입력해주세요'
+                  {...register('description')}
+                />
+                {errors.description && <p className='text-red-500'>{errors.description.message}</p>}
+              </div>
             </div>
             <div className='grid grid-cols-4 items-center gap-5'>
               <Label
@@ -118,13 +152,14 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
               >
                 상세 설명
               </Label>
-              <Input
-                id='content'
-                placeholder='자세한 설명을 입력해주세요'
-                className='col-span-3'
-                value={value.content ?? ''}
-                onChange={(e) => setValue({ ...value, content: e.target.value })}
-              />
+              <div className='flex flex-col col-span-3'>
+                <Input
+                  id='content'
+                  placeholder='자세한 설명을 입력해주세요'
+                  {...register('content')}
+                />
+                {errors.content && <p className='text-red-500'>{errors.content.message}</p>}
+              </div>
             </div>
           </div>
           <DialogFooter>

--- a/src/components/calendar/ScheduleEditButton.tsx
+++ b/src/components/calendar/ScheduleEditButton.tsx
@@ -45,11 +45,6 @@ export default function ScheduleEditButton({ schedule }: { schedule: Schedule })
 
   const { mutate } = useUpdateSchedule();
   const handleEditSchedule = (data: ScheduleFormValues) => {
-    if (!date) {
-      alert('알맞은 date값이 아닙니다.');
-      return;
-    }
-
     const updateData = {
       scheduleId: schedule.id,
       title: data.title,

--- a/src/components/calendar/ScheduleList.tsx
+++ b/src/components/calendar/ScheduleList.tsx
@@ -6,15 +6,13 @@ import useScheduleStore from '@/lib/stores/useScheduleStore';
 import { isSameDay } from '@/utils/calendar/calendarUtils';
 import ScheduleDeleteButton from '@/components/calendar/ScheduleDeleteButton';
 import ScheduleEditButton from '@/components/calendar/ScheduleEditButton';
+import { useAuthStore } from '@/lib/stores/useAuthStore';
 
-// TODO: 유나님 zustand merge 후 zustand에서 받아오기
-type TempCalendarInitialType = CalendarInitDataType & {
-  userId: string | undefined;
-};
-
-export default function ScheduleList({ artistId, userId }: TempCalendarInitialType) {
+export default function ScheduleList({ artistId }: { artistId: string }) {
   const { calendarDate, selectedDate } = useScheduleStore((state) => state);
   let { data: schedules } = useFetchSchedules(artistId, calendarDate);
+
+  const { user } = useAuthStore((state) => state);
 
   if (selectedDate && schedules) {
     schedules = schedules.filter((schedule) => isSameDay(selectedDate, schedule.date));
@@ -28,7 +26,7 @@ export default function ScheduleList({ artistId, userId }: TempCalendarInitialTy
             key={schedule.id}
             className='relative w-full border p-3'
           >
-            {schedule.user_id === userId && (
+            {schedule.user_id === user?.id && (
               <div className='absolute right-3 bottom-3 flex'>
                 <ScheduleEditButton schedule={schedule} />
                 <ScheduleDeleteButton scheduleId={schedule.id} />

--- a/src/components/calendar/ScheduleList.tsx
+++ b/src/components/calendar/ScheduleList.tsx
@@ -12,9 +12,9 @@ type TempCalendarInitialType = CalendarInitDataType & {
   userId: string | undefined;
 };
 
-export default function ScheduleList({ artistId, initialDate, userId }: TempCalendarInitialType) {
-  let { data: schedules } = useFetchSchedules(artistId, initialDate);
-  const { selectedDate } = useScheduleStore();
+export default function ScheduleList({ artistId, userId }: TempCalendarInitialType) {
+  const { calendarDate, selectedDate } = useScheduleStore((state) => state);
+  let { data: schedules } = useFetchSchedules(artistId, calendarDate);
 
   if (selectedDate && schedules) {
     schedules = schedules.filter((schedule) => isSameDay(selectedDate, schedule.date));

--- a/src/components/calendar/ScheduleList.tsx
+++ b/src/components/calendar/ScheduleList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarInitDataType, Schedule } from '@/lib/type/scheduleTypes';
+import { Schedule } from '@/lib/type/scheduleTypes';
 import { useFetchSchedules } from '@/queries/fetchSchedules';
 import useScheduleStore from '@/lib/stores/useScheduleStore';
 import { isSameDay } from '@/utils/calendar/calendarUtils';

--- a/src/components/calendar/ScheduleList.tsx
+++ b/src/components/calendar/ScheduleList.tsx
@@ -26,10 +26,10 @@ export default function ScheduleList({ artistId, initialDate, userId }: TempCale
         schedules.map((schedule: Schedule) => (
           <div
             key={schedule.id}
-            className='relative w-full h-[100px] border p-3'
+            className='relative w-full border p-3'
           >
             {schedule.user_id === userId && (
-              <div className='absolute right-3 top-3 flex gap-1'>
+              <div className='absolute right-3 bottom-3 flex'>
                 <ScheduleEditButton schedule={schedule} />
                 <ScheduleDeleteButton scheduleId={schedule.id} />
               </div>

--- a/src/lib/stores/useScheduleStore.ts
+++ b/src/lib/stores/useScheduleStore.ts
@@ -3,11 +3,15 @@ import { create } from 'zustand';
 type ScheduleStore = {
   selectedDate: number | null;
   selectDate: (date: number | null) => void;
+  calendarDate: Date;
+  setCalendarDate: (date: Date) => void;
 };
 
 const useScheduleStore = create<ScheduleStore>((set) => ({
   selectedDate: null,
   selectDate: (date) => set({ selectedDate: date }),
+  calendarDate: new Date(),
+  setCalendarDate: (date) => set({ calendarDate: date }),
 }));
 
 export default useScheduleStore;

--- a/src/lib/type/scheduleTypes.ts
+++ b/src/lib/type/scheduleTypes.ts
@@ -5,6 +5,5 @@ export type ScheduleInsert = Database['public']['Tables']['schedule']['Insert'];
 export type ScheduleUpdate = Database['public']['Tables']['schedule']['Update'];
 
 export type CalendarInitDataType = {
-  initialDate: Date;
   artistId: string;
 };

--- a/src/lib/type/scheduleTypes.ts
+++ b/src/lib/type/scheduleTypes.ts
@@ -3,7 +3,3 @@ import { Database } from '@/lib/type/database.types';
 export type Schedule = Database['public']['Tables']['schedule']['Row'];
 export type ScheduleInsert = Database['public']['Tables']['schedule']['Insert'];
 export type ScheduleUpdate = Database['public']['Tables']['schedule']['Update'];
-
-export type CalendarInitDataType = {
-  artistId: string;
-};

--- a/src/utils/useRequireSigninDialog.tsx
+++ b/src/utils/useRequireSigninDialog.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+export default function useRequireSigninDialog() {
+  const [open, setOpen] = useState<boolean>(false);
+  const router = useRouter();
+
+  const showDialog = () => setOpen(true);
+
+  const handleConfirm = () => {
+    setOpen(false);
+    router.push('/signIn');
+  };
+
+  const SignInDialog = () => {
+    return (
+      <AlertDialog
+        open={open}
+        onOpenChange={setOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>로그인이 필요합니다</AlertDialogTitle>
+            <AlertDialogDescription>
+              이 기능을 사용하려면 로그인이 필요합니다. 로그인 페이지로 이동하시겠습니까?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button onClick={handleConfirm}>확인</Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  };
+  return { showDialog, SignInDialog };
+}

--- a/src/utils/zod/scheduleSchema.ts
+++ b/src/utils/zod/scheduleSchema.ts
@@ -9,7 +9,7 @@ export const scheduleSchema = z.object({
     .refine((d) => d !== null, {
       message: '날짜는 필수 항목입니다.',
     }),
-  content: z.string().optional(),
+  content: z.string().nullable(),
 });
 
 export type ScheduleFormValues = z.infer<typeof scheduleSchema>;


### PR DESCRIPTION
## What is this PR? 🔍
- 캘린더 및 스케줄 아이템 높이 수정 (콘텐츠 높이에 따라 달라지도록 제한 두지 않음)
- 캘린더 년/월 변경시 우측 스케줄 리스트가 같이 변경되지 않던 버그 수정
- 유저 정보 zustand store에서 받아오는 것으로 변경
- 스케줄 작성/수정 모달에 들어가 날짜를 한 번 선택하면 다시 모달을 열었을 때 이전에 선택했던 날짜가 선택되어있는 버그 수정
- day picker locale 설정
- user 데이터가 존재하지 않을 때 로그인 페이지로 이동시키는 alert dialog 생성
<br/>

## Screenshot 📸
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/97e82fc0-b534-450c-9737-b59d55a96c2a">

<br/>

## Test Checklist ☑️
- [x] 달력 앞뒤로 조정할 때 캘린더 리스트/선택한 날짜 초기화되는 것 확인

<br/>

## Others 👻